### PR TITLE
Update gamedata for TF2 version 7757534 (2023-01-05)

### DIFF
--- a/addons/sourcemod/gamedata/melee.txt
+++ b/addons/sourcemod/gamedata/melee.txt
@@ -6,8 +6,8 @@
 		{
 			"CTFWeaponBase::WeaponReset"
 			{
-				"linux"		"430"
-				"windows"	"423"
+				"linux"		"433"
+				"windows"	"426"
 			}
 		}
 	}

--- a/addons/sourcemod/gamedata/melee.txt
+++ b/addons/sourcemod/gamedata/melee.txt
@@ -6,8 +6,8 @@
 		{
 			"CTFWeaponBase::WeaponReset"
 			{
-				"linux"		"433"
-				"windows"	"426"
+				"linux"		"434"
+				"windows"	"427"
 			}
 		}
 	}


### PR DESCRIPTION
Brings gamedata up to date with the recent TF2 release.

(Note that there may be breakages elsewhere in the plugin.  I'd suggest independently verifying that the gamedata works.)